### PR TITLE
api/recipes/{id} レシピ詳細＋使用食材取得

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -213,10 +213,8 @@ func recipeDetailHandler(w http.ResponseWriter, r *http.Request) {
 
 	// JSONレスポンス
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]interface{}{
-		"recipe":      recipe,
-		"ingredients": ingredients,
-	})
+	resp := RecipeWithIngredients{Recipe: recipe, Ingredients: ingredients}
+	json.NewEncoder(w).Encode(resp)
 }
 
 func main() {

--- a/backend/main.go
+++ b/backend/main.go
@@ -169,7 +169,7 @@ func ingredientsHandler(w http.ResponseWriter, r *http.Request) {
 
 // /api/recipes/{id} レシピ詳細＋使用食材取得
 func recipeDetailHandler(w http.ResponseWriter, r *http.Request) {
-	// URLからidを抽出
+	// URLからIDを取得
 	idStr := r.URL.Path[len("/api/recipes/"):]
 	id, err := strconv.Atoi(idStr)
 	if err != nil {
@@ -179,8 +179,11 @@ func recipeDetailHandler(w http.ResponseWriter, r *http.Request) {
 
 	// レシピ情報を取得
 	var recipe Recipe
-	err = db.QueryRow("SELECT id, name, category, prep_time_minutes, cook_time_minutes, servings, difficulty, instructions, description FROM recipes WHERE id = ?", id).
-		Scan(&recipe.ID, &recipe.Name, &recipe.Category, &recipe.PrepTimeMinutes, &recipe.CookTimeMinutes, &recipe.Servings, &recipe.Difficulty, &recipe.Instructions, &recipe.Description)
+	err = db.QueryRow(`
+		SELECT id, name, category, prep_time_minutes, cook_time_minutes, servings, difficulty, instructions, description 
+		FROM recipes WHERE id = ?`, id).
+		Scan(&recipe.ID, &recipe.Name, &recipe.Category, &recipe.PrepTimeMinutes, &recipe.CookTimeMinutes,
+			&recipe.Servings, &recipe.Difficulty, &recipe.Instructions, &recipe.Description)
 	if err != nil {
 		http.Error(w, "Recipe not found", http.StatusNotFound)
 		return
@@ -188,10 +191,10 @@ func recipeDetailHandler(w http.ResponseWriter, r *http.Request) {
 
 	// 使用食材を取得
 	rows, err := db.Query(`
-        SELECT i.id, i.name, ri.quantity, ri.unit, ri.notes
-        FROM recipes_ingredients ri
-        JOIN ingredients i ON ri.ingredient_id = i.id
-        WHERE ri.recipe_id = ?`, id)
+		SELECT i.id, i.name, ri.quantity, ri.unit, ri.notes
+		FROM recipes_ingredients ri
+		JOIN ingredients i ON ri.ingredient_id = i.id
+		WHERE ri.recipe_id = ?`, id)
 	if err != nil {
 		http.Error(w, "Database error", http.StatusInternalServerError)
 		return
@@ -201,15 +204,18 @@ func recipeDetailHandler(w http.ResponseWriter, r *http.Request) {
 	var ingredients []IngredientWithQuantity
 	for rows.Next() {
 		var ing IngredientWithQuantity
-		rows.Scan(&ing.IngredientID, &ing.Name, &ing.Quantity, &ing.Unit, &ing.Notes)
+		if err := rows.Scan(&ing.IngredientID, &ing.Name, &ing.Quantity, &ing.Unit, &ing.Notes); err != nil {
+			http.Error(w, "Database error", http.StatusInternalServerError)
+			return
+		}
 		ingredients = append(ingredients, ing)
 	}
 
 	// JSONレスポンス
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(RecipeWithIngredients{
-		Recipe:      recipe,
-		Ingredients: ingredients,
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"recipe":      recipe,
+		"ingredients": ingredients,
 	})
 }
 


### PR DESCRIPTION
### 概要
- レシピ詳細API `/api/recipes/{id}` を追加
- レシピ本体と使用食材（分量・単位付き）を返すようにしました

### 動作確認
1. ローカルでDBにテストデータを投入
2. サーバ起動後、以下のコマンドで確認
curl -s ‘http://localhost:8000/api/recipes/1’ | jq .